### PR TITLE
Get the stream_min_example to compile, link and run (a bit)

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+stream_min_example

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,26 @@
+CC = gcc
+
+EXE = stream_min_example
+OBJS = stream_min_example.o
+LIBS = ../src/RfsocTransmitter.o ../src/RfsocBuilder.o \
+       -lso3g -lspt3g-core \
+       -lboost_system -lboost_python38 \
+       -pthread -lpython3.8 -lstdc++
+
+CFLAGS = -I ../include -I /usr/local/include/spt3g/core -I /usr/local/include/spt3g \
+       	 -I /home/ubuntu/so3g/include -I /usr/include/python3.8 \
+       	 -I /home/ubuntu/.local/lib/python3.8/site-packages/numpy/core/include
+
+LFLAGS = -L /usr/local/lib/python3.8/dist-packages/so3g
+
+all: $(EXE)
+
+stream_min_example.o: stream_min_example.cxx
+	$(CC) -c -o $@ $(CFLAGS) $^
+
+stream_min_example: $(OBJS)
+	$(CC) -o stream_min_example $(LFLAGS) $(OBJS) $(LIBS)
+
+clean:
+	rm -f $(EXE)
+

--- a/scripts/stream_min_example.cxx
+++ b/scripts/stream_min_example.cxx
@@ -1,3 +1,5 @@
+#include <boost/shared_ptr.hpp>
+
 #include <core/pybindings.h>
 #include <core/G3.h>
 #include <core/G3Pipeline.h>
@@ -13,17 +15,17 @@
  * Modeled on sp3g_software/examples/cppexample.cxx
 */
 
-int main{
-
+int main()
+{
     // Initializing interpreter and releasing GIL
     // Borrowed from spt3g_software/examples/cppexample.cxx
     // May need changed for our usage, but will leave for now
     G3PythonInterpreter interp(false);
 
     G3Pipeline pipe;
-    RfsocBuilder builder;
-    RfsocTransmitter transmitter(builder);
-    transmitter.Start();
+    boost::shared_ptr<RfsocBuilder> builder = boost::make_shared<RfsocBuilder>();
+    RfsocTransmitter* transmitter = new RfsocTransmitter(builder);
+    transmitter->Start();
 
     pipe.Add(builder);
     pipe.Add(G3ModulePtr(new G3Writer("/data/test.g3")));
@@ -32,3 +34,4 @@ int main{
 
     return 0;
 }
+


### PR DESCRIPTION
A few changes were made to the existing code to get it to compile, in particular, the use of a boost shared pointer type that is used by base classes through the so3g code.

I changed the transmitter variable to be a pointer, which may not have been strictly necessary, but may be helpful if we extend this code to do more and need to pass the transmitter as a parameter (that is better done with pointers than objects).  You may be familiar with it, but in C++ you reference members of an object differently when your variable is the object (reference through .) or is a pointer (reference through ->).  I think the use of an object variable for the pipe is fine, as it should never be passed to anyone.

As with the previous submission in "src", the Makefile is a temporary placeholder that is only known to work on Ben's cloud instance.  We will want to come up with a solid installation plan that can be repeated on any system and then the Makefile (or a CMake setup) will reference the expected, consistent locations of things that have been installed.

Chris and I both feel that this folder should be renamed from "scripts".  That is a Python practice, and what we have here isn't really a script.  Perhaps "test" would be a good name, as this is a small test program to exercise the code in the library, which is the main product of this repo.  We may want to add other unit tests and integration tests to this folder at some point.

We should also make a decision about the file extension we use for all C++ files in this work.  I don't personally care, cpp and cxx are both commonly used.  We should just use the same extension on all files.
