### PR TITLE
Fixing numpy PyArray segfault in stream_min_example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,72 @@ rfsoc-streamer
 # on an instance running ubuntu22
 # confirmed /usr/bin/python3 is running 3.10
 
+# set up ssh keys or other authentication method to enable git clone from github
+
 sudo apt-get update
-sudo apt install python3.10-venv
+sudo apt install gcc g++
+sudo apt install make
+sudo apt install python3-dev
+sudo apt-get install libboost-all-dev
+sudo apt install python3.10-venv 
+sudo apt install libopenblas-openmp-dev libflac-dev bzip2 libbz2-dev 
 #
-python3 -m venv streamer_test1
-source streamer_test1/bin/activate
+python3 -m venv streamer_test
+source streamer_test/bin/activate
 pip install --upgrade pip
 #
 mkdir ~/git
 cd ~/git
 git clone git@github.com:simonsobs/so3g.git
-#
-cd so3g
-pip install -r requirements.txt
-#
-pip install so3g
-#
-cd ~/git
-git clone git@github.com:ccatobs/rfsoc-streamer.git
 git clone git@github.com:CMB-S4/spt3g_software.git
+git clone git@github.com:ccatobs/rfsoc-streamer.git
 #
-sudo apt install gcc g++
-sudo apt install make
-sudo apt-get install libboost-all-dev
+cd ~/git/so3g
+pip install -r requirements.txt
+mkdir ~/so3g
 #
-export LD_LIBRARY_PATH=/home/ubuntu/streamer_test1/lib/python3.10/site-packages/so3g/spt3g_internal/:/home/ubuntu/streamer_test1/lib/python3.10/site-packages/so3g/
+cd ~/git/spt3g_software
+mkdir -p build
+cd build
 
-make                               # this will make stream_min_example
+cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_COMPILER="gcc" \
+  -DCMAKE_CXX_COMPILER="g++" \
+  -DCMAKE_C_FLAGS="-O3 -g -fPIC" \
+  -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -std=c++11" \
+  -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+  -DPython_EXECUTABLE:FILEPATH=$(which python3) \
+  -DPYTHON_MODULE_DIR="${HOME}/so3g/lib/python3.10/site-packages" \
+  -DCMAKE_INSTALL_PREFIX="${HOME}/so3g" \
+  ..
+
+make
+make install
+#
+cd ~/git/so3g
+mkdir -p build
+cd build
+
+cmake \
+  -DCMAKE_PREFIX_PATH=${HOME}/git/spt3g_software/build \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+  -DPYTHON_INSTALL_DEST="${HOME}/so3g" \
+  -DCMAKE_INSTALL_PREFIX="${HOME}/so3g" \
+  ..
+
+make
+make install
+#
+cd ~/git/rfsoc-streamer
+cd src
+make
+
+cd ../test
+make
+
+export LD_LIBRARY_PATH=/home/ubuntu/so3g/lib:/home/ubuntu/so3g/so3g
 ./stream_min_example   # this will eventually segfault, but not before creating an empty test.g3 in the data directory
 
 make cppexample           # this will make cppexample

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,7 @@ OBJ = RfsocBuilder.o RfsocTransmitter.o
 
 CFLAGS = -g -pthread -I ../include -I /home/ubuntu/git/spt3g_software/core/include/core -I /home/ubuntu/git/spt3g_software/core/include \
          -I /home/ubuntu/git/so3g/include -I /usr/include/python3.10 \
-         -I /home/ubuntu/streamer_test1/lib/python3.10/site-packages/numpy/core/include/ \
-         -D_GLIBCXX_USE_CXX11_ABI=0
+         -I /home/ubuntu/streamer_test/lib/python3.10/site-packages/numpy/core/include/ \
 
 all: $(OBJ)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,15 +6,12 @@ LIBS = ../src/RfsocTransmitter.o ../src/RfsocBuilder.o \
        -Wl,--copy-dt-needed-entries \
        -lspt3g-core -lso3g -lboost_system -lboost_python310 -pthread -lpython3.10 -lstdc++
 
-CFLAGS = -g -pthread \
-         -I ../include -I /home/ubuntu/git/spt3g_software/core/include/core -I /home/ubuntu/git/spt3g_software/core/include \
-       	 -I /home/ubuntu/git/so3g/include -I /usr/include/python3.10 \
-       	 -I /home/ubuntu/streamer_test1/lib/python3.10/site-packages/numpy/core/include/ \
-         -D_GLIBCXX_USE_CXX11_ABI=0
-         
-LFLAGS = -L /home/ubuntu/streamer_test1/lib/python3.10/site-packages/so3g/spt3g_internal/ \
-         -L /home/ubuntu/streamer_test1/lib/python3.10/site-packages/so3g \
-         -L /home/ubuntu/streamer_test1/lib/python3.10/site-packages/so3g.libs
+CFLAGS = --std=c++11 -g -pthread \
+        -I ../include -I /home/ubuntu/git/spt3g_software/core/include/core -I /home/ubuntu/git/spt3g_software/core/include \
+        -I /home/ubuntu/git/so3g/include -I /usr/include/python3.10 -I /home/ubuntu/streamer_test/lib/python3.10/site-packages/numpy/core/include/
+
+LFLAGS = -L /home/ubuntu/so3g/lib -L /home/ubuntu/so3g/so3g
+
 
 all: $(EXE)
 

--- a/test/stream_min_example.cxx
+++ b/test/stream_min_example.cxx
@@ -1,3 +1,5 @@
+#define PY_ARRAY_UNIQUE_SYMBOL Py_Array_API_SO3G
+
 #include <boost/shared_ptr.hpp>
 
 #include <core/pybindings.h>
@@ -6,6 +8,8 @@
 #include <core/G3Writer.h>
 #include <RfsocBuilder.h>
 #include <RfsocTransmitter.h>
+#include <so3g_numpy.h>
+
 
 // Need to include spt3g_software? So3g?
 
@@ -20,7 +24,10 @@ int main()
     // Initializing interpreter and releasing GIL
     // Borrowed from spt3g_software/examples/cppexample.cxx
     // May need changed for our usage, but will leave for now
-    //G3PythonInterpreter interp(false);
+    G3PythonInterpreter interp(true);
+
+    import_array();
+    printf("PyArray_API: %p\n", PyArray_API);
 
     G3Pipeline pipe;
     boost::shared_ptr<RfsocBuilder> builder = boost::make_shared<RfsocBuilder>();


### PR DESCRIPTION
This addresses a segfault encountered when running the stream_min_example executable, associated with the fact that calls to various PyArray_ creation functions will not correctly unless all source files are pointing to the same statically compiled table of function pointers (see this documentation for general discussion of the issue: https://numpy.org/doc/stable/reference/c-api/array.html#including-and-importing-the-c-api ).  This new version of the code gets past the place where stream_min_example previously segfaulted, and encounters a new error downstream that throws a 'g3supertimestream_exception', which might be due to the fact that there is not yet any data in the pipeline to be processed.

The README describes an updated process for installing and building all the relevant software on an ubuntu22 instance (running python3.10 by default).  This process now involves compiling so3g and spt3g from source in a debug release, rather than doing a pip install, since that has enabled us to figure out where the original segfault was taking place.  Once everything is working, we would presumably want to recompile for a non-debug release, but in the meantime, we'll have some more debugging to do in order to make sense of the 'g3supertimestream_exception'.

This branch includes modifications to the rfsoc-streamer Makefiles and to the stream_min_example.cxx code.