### PR TITLE
Add timestream name to RfsocBuilder to avoid g3 timestream exception

### DIFF
--- a/src/RfsocBuilder.cxx
+++ b/src/RfsocBuilder.cxx
@@ -135,6 +135,10 @@ G3FramePtr RfsocBuilder::FrameFromSamples(
  
     int data_shape[2] = {nchans, nsamps};
     auto data_ts = G3SuperTimestreamPtr(new G3SuperTimestream());
+    data_ts->names = G3VectorString();
+    for (int i = 0; i < nchans; i++){
+        data_ts->names.push_back("test_channel");
+    }
 
     G3VectorTime sample_times = G3VectorTime(nsamps);
 


### PR DESCRIPTION
I figured out that the g3 supertimestream exception was getting thrown because the G3SuperTimestreamPtr data_ts in RfsocBuilder::FrameFromSamples was not being given names in association with the channels.  I added a little code to that function to give a name ("test_channel") and remade both the files in src and in test.  The stream_min_example program now seems to run without a segfault, and dumps data into a g3 file.  It just seems to keep running, so I killed it after a little while and then checked the contents of the g3 file it wrote (using the cppexample in the test directory, which just copies a g3 file and prints out the contents).  The contents of the g3 file written by stream_min_example are included below.   I think we should rebuild the src and test files on the lab machine, and see if it is able to produce a g3 file.

Frame (None) [
"time" (G3Time) => 22-Oct-2024:17:30:11.413997000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 648362)
"num_samples" (G3Int) => 648362
"time" (G3Time) => 22-Oct-2024:17:30:14.713144000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 504389)
"num_samples" (G3Int) => 504389
"time" (G3Time) => 22-Oct-2024:17:30:17.668695000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 532192)
"num_samples" (G3Int) => 532192
"time" (G3Time) => 22-Oct-2024:17:30:20.668791000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 489217)
"num_samples" (G3Int) => 489217
"time" (G3Time) => 22-Oct-2024:17:30:23.656762000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 557136)
"num_samples" (G3Int) => 557136
"time" (G3Time) => 22-Oct-2024:17:30:26.668445000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 558511)
"num_samples" (G3Int) => 558511
"time" (G3Time) => 22-Oct-2024:17:30:29.701348000
]
Frame (Scan) [
"data" (G3SuperTimestream) => G3SuperTimestream(1, 542070)
"num_samples" (G3Int) => 542070
"time" (G3Time) => 22-Oct-2024:17:30:32.677521000
]
